### PR TITLE
Setting background colour in config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+backgroundColor="#FFFFFF"

--- a/streamlit_viz/.streamlit/config.toml
+++ b/streamlit_viz/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+backgroundColor="#FFFFFF"


### PR DESCRIPTION
Closes #10 
Adds a set background colour to the config, overriding the default behaviour of setting the background to navy/black if user uses dark mode. Not 100% sure this will work on streamlit share but works locally.