### PR TITLE
pip cython version to solve sklearn issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cython<3
 colour==0.1.5
 streamlit_agraph==0.0.42
 streamlit==1.16.0


### PR DESCRIPTION
Our streamlit app was broken due to a sklearn issue.

Other's have had this [sklearn issue](https://github.com/scikit-learn/scikit-learn/issues/26858) and the solution is to pin the cython version.

![Screenshot 2023-08-08 at 09 32 39](https://github.com/nestauk/ojd-daps-skills-analysis/assets/15956065/7b8a39ba-f0b7-454f-9eb6-b87c9cbe96a7)
